### PR TITLE
Fix IDE warnings, specially some related to generics

### DIFF
--- a/src/main/java/org/aika/Activation.java
+++ b/src/main/java/org/aika/Activation.java
@@ -189,11 +189,11 @@ public class Activation implements Comparable<Activation> {
         Node.ThreadState th = n.getThreadState(t);
         int s = th.activations.size();
 
-        if(s == 0) return Collections.EMPTY_LIST;
+        if(s == 0) return Collections.emptyList();
         else if(s == 1) {
             Activation act = th.activations.firstEntry().getValue();
             if (act.filter(n, rid, r, rr, o, or)) return Collections.singletonList(act);
-            else return Collections.EMPTY_LIST;
+            else return Collections.emptyList();
         }
 
         List<Activation> results = new ArrayList<>();

--- a/src/main/java/org/aika/Model.java
+++ b/src/main/java/org/aika/Model.java
@@ -18,15 +18,9 @@ package org.aika;
 
 
 import org.aika.corpus.Document;
-import org.aika.corpus.Option;
-import org.aika.corpus.Range;
 import org.aika.lattice.AndNode;
-import org.aika.lattice.InputNode;
-import org.aika.neuron.Neuron.NormWeight;
 import org.aika.neuron.Neuron;
 import org.aika.lattice.Node;
-import org.aika.Activation.State;
-import org.aika.lattice.AndNode.Refinement;
 import org.aika.neuron.Synapse;
 
 

--- a/src/main/java/org/aika/corpus/ExpandNode.java
+++ b/src/main/java/org/aika/corpus/ExpandNode.java
@@ -376,7 +376,7 @@ public class ExpandNode implements Comparable<ExpandNode> {
 
     private void markExcluded(List<Option> changed, long v, Option n) {
         List<Option> conflicting = new ArrayList<>();
-        n.conflicts.collectAllConflicting(conflicting, n, Option.visitedCounter++);
+        Conflicts.collectAllConflicting(conflicting, n, Option.visitedCounter++);
         for(Option cn: conflicting) {
             markExcludedRecursiveStep(changed, v, cn);
         }
@@ -413,6 +413,8 @@ public class ExpandNode implements Comparable<ExpandNode> {
 
 
     public static class ExpandNodeException extends RuntimeException {
+
+        private static final long serialVersionUID = -9084467053069262753L;
 
     }
 

--- a/src/main/java/org/aika/corpus/Option.java
+++ b/src/main/java/org/aika/corpus/Option.java
@@ -18,6 +18,7 @@ package org.aika.corpus;
 
 
 import org.aika.Iteration;
+import org.aika.lattice.Node;
 import org.aika.Activation;
 import org.aika.Activation.Key;
 
@@ -246,7 +247,7 @@ public class Option implements Comparable<Option> {
 
         for (Activation act : getActivations()) {
             if (act.key.o.contains(conflict, false)) {
-                act.key.n.removeActivationAndPropagate(t, act, act.inputs.values());
+                Node.removeActivationAndPropagate(t, act, act.inputs.values());
             }
         }
 
@@ -261,12 +262,12 @@ public class Option implements Comparable<Option> {
 
 
     public Collection<Activation> getActivations() {
-        return activations != null ? activations.values() : Collections.EMPTY_SET;
+        return activations != null ? activations.values() : Collections.emptySet();
     }
 
 
     public Collection<Activation> getNeuronActivations() {
-        return neuronActivations != null ? neuronActivations : Collections.EMPTY_SET;
+        return neuronActivations != null ? neuronActivations : Collections.emptySet();
     }
 
 

--- a/src/main/java/org/aika/lattice/AndNode.java
+++ b/src/main/java/org/aika/lattice/AndNode.java
@@ -20,7 +20,6 @@ package org.aika.lattice;
 import org.aika.*;
 import org.aika.corpus.Option;
 import org.aika.corpus.Range;
-import org.aika.Iteration.Input;
 import org.aika.Activation.Key;
 import org.aika.neuron.Neuron;
 import org.aika.neuron.Synapse;

--- a/src/main/java/org/aika/lattice/Node.java
+++ b/src/main/java/org/aika/lattice/Node.java
@@ -19,7 +19,6 @@ package org.aika.lattice;
 
 import org.aika.*;
 import org.aika.corpus.Conflicts;
-import org.aika.corpus.ExpandNode;
 import org.aika.corpus.Option;
 import org.aika.corpus.Range;
 import org.aika.neuron.*;

--- a/src/main/java/org/aika/neuron/InputNeuron.java
+++ b/src/main/java/org/aika/neuron/InputNeuron.java
@@ -98,7 +98,7 @@ public class InputNeuron extends Neuron {
 
 
     public void addInput(Iteration t, int begin, int end, Integer rid, Option o) {
-        Node.addActivationAndPropagate(t, new Activation.Key(node, new Range(begin, end), rid, o), Collections.EMPTY_SET);
+        Node.addActivationAndPropagate(t, new Activation.Key(node, new Range(begin, end), rid, o), Collections.emptySet());
 
         t.propagate();
     }
@@ -122,7 +122,7 @@ public class InputNeuron extends Neuron {
     public void removeInput(Iteration t, int begin, int end, Integer rid, Option o) {
         Range r = new Range(begin, end);
         Activation act = Activation.get(t, node, rid, r, Range.Relation.EQUALS, o, Option.Relation.EQUALS);
-        Node.removeActivationAndPropagate(t, act, Collections.EMPTY_SET);
+        Node.removeActivationAndPropagate(t, act, Collections.emptySet());
 
         t.propagate();
     }

--- a/src/test/java/org/aika/network/ActivationsTest.java
+++ b/src/test/java/org/aika/network/ActivationsTest.java
@@ -104,15 +104,15 @@ public class ActivationsTest {
         Neuron in = t.createOrLookupInputSignal("A");
         InputNode inNode = (InputNode) in.node;
 
-        inNode.addActivationInternal(t, new Activation.Key(inNode, new Range(0, 1), 0, doc.bottom), Collections.EMPTY_LIST, false);
+        inNode.addActivationInternal(t, new Activation.Key(inNode, new Range(0, 1), 0, doc.bottom), Collections.emptyList(), false);
 
-        inNode.addActivationInternal(t, new Activation.Key(inNode, new Range(0, 1), 0, doc.bottom), Collections.EMPTY_LIST, false);
+        inNode.addActivationInternal(t, new Activation.Key(inNode, new Range(0, 1), 0, doc.bottom), Collections.emptyList(), false);
 
-        inNode.addActivationInternal(t, new Activation.Key(inNode, new Range(0, 1), 0, doc.bottom), Collections.EMPTY_LIST, false);
+        inNode.addActivationInternal(t, new Activation.Key(inNode, new Range(0, 1), 0, doc.bottom), Collections.emptyList(), false);
 
-        inNode.addActivationInternal(t, new Activation.Key(inNode, new Range(0, 1), 0, doc.bottom), Collections.EMPTY_LIST, false);
+        inNode.addActivationInternal(t, new Activation.Key(inNode, new Range(0, 1), 0, doc.bottom), Collections.emptyList(), false);
 
-        inNode.addActivationInternal(t, new Activation.Key(inNode, new Range(0, 1), 0, doc.bottom), Collections.EMPTY_LIST, false);
+        inNode.addActivationInternal(t, new Activation.Key(inNode, new Range(0, 1), 0, doc.bottom), Collections.emptyList(), false);
 
  //       Assert.assertEquals(1, Activation.get(t, inNode, new Range(0, 1), doc.bottom).key.fired);
     }

--- a/src/test/java/org/aika/network/OrOptionsTest.java
+++ b/src/test/java/org/aika/network/OrOptionsTest.java
@@ -72,15 +72,15 @@ public class OrOptionsTest {
 
         Option o0 = Option.addPrimitive(doc);
         Range r = new Range(0, 10);
-        Node.addActivationAndPropagate(t, new Activation.Key(inA.node, r, 0, o0), Collections.EMPTY_SET);
+        Node.addActivationAndPropagate(t, new Activation.Key(inA.node, r, 0, o0), Collections.emptySet());
         t.propagate();
 
         Option o1 = Option.addPrimitive(doc);
-        Node.addActivationAndPropagate(t, new Activation.Key(inA.node, r, 0, o1), Collections.EMPTY_SET);
+        Node.addActivationAndPropagate(t, new Activation.Key(inA.node, r, 0, o1), Collections.emptySet());
         t.propagate();
 
         Option o2 = Option.addPrimitive(doc);
-        Node.addActivationAndPropagate(t, new Activation.Key(inA.node, r, 0, o2), Collections.EMPTY_SET);
+        Node.addActivationAndPropagate(t, new Activation.Key(inA.node, r, 0, o2), Collections.emptySet());
         t.propagate();
 
 

--- a/src/test/java/org/aika/network/SynapseRangeRelationTest.java
+++ b/src/test/java/org/aika/network/SynapseRangeRelationTest.java
@@ -64,10 +64,10 @@ public class SynapseRangeRelationTest {
         s.output = on;
         s.link(t);
 
-        Activation iAct0 = in.node.addActivationInternal(t, new Key(in.node, new Range(1, 4), null, t.doc.bottom), Collections.EMPTY_LIST, false);
-        Activation iAct1 = in.node.addActivationInternal(t, new Key(in.node, new Range(6, 7), null, t.doc.bottom), Collections.EMPTY_LIST, false);
-        Activation iAct2 = in.node.addActivationInternal(t, new Key(in.node, new Range(10, 18), null, t.doc.bottom), Collections.EMPTY_LIST, false);
-        Activation oAct = on.node.addActivationInternal(t, new Key(on.node, new Range(6, 7), null, t.doc.bottom), Collections.EMPTY_LIST, false);
+        Activation iAct0 = in.node.addActivationInternal(t, new Key(in.node, new Range(1, 4), null, t.doc.bottom), Collections.emptyList(), false);
+        Activation iAct1 = in.node.addActivationInternal(t, new Key(in.node, new Range(6, 7), null, t.doc.bottom), Collections.emptyList(), false);
+        Activation iAct2 = in.node.addActivationInternal(t, new Key(in.node, new Range(10, 18), null, t.doc.bottom), Collections.emptyList(), false);
+        Activation oAct = on.node.addActivationInternal(t, new Key(on.node, new Range(6, 7), null, t.doc.bottom), Collections.emptyList(), false);
 
         Assert.assertTrue(oAct.neuronInputs.contains(new SynapseActivation(s, iAct1, oAct)));
     }

--- a/src/test/java/org/aika/network/TestHelper.java
+++ b/src/test/java/org/aika/network/TestHelper.java
@@ -37,7 +37,7 @@ public class TestHelper {
 
 
     public static Activation addActivationAndPropagate(Iteration t, Activation.Key ak) {
-        return addActivationAndPropagate(t, ak, Collections.EMPTY_SET);
+        return addActivationAndPropagate(t, ak, Collections.emptySet());
     }
 
 


### PR DESCRIPTION
Found with Eclipse. Did not "organise imports" as that would generate a much bigger diff with no reason. Tests failing with several NPE, but I think it's due to some current changes in the code?

Thanks
Bruno