### PR TITLE
Expand gitignore, to support more IDEA files, and Eclipse and Maven files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,21 @@
-.idea/*
+# Maven build files
+target
+*.log
+maven-eclipse.xml
+build.properties
+site-content
+*~
+
+# IntelliJ IDEA files
+.idea
+.iws
 *.iml
+*.ipr
+
+# Eclipse files
+.settings
+.classpath
+.project
+.externalToolBuilders
+.checkstyle
+


### PR DESCRIPTION
From Apache Commons Lang. It normally works well with most projects. Otherwise we can add more examples from https://github.com/github/gitignore