### PR TITLE
fix formatting exception

### DIFF
--- a/src/main/java/network/aika/storage/FSSuspensionCallbackImpl.java
+++ b/src/main/java/network/aika/storage/FSSuspensionCallbackImpl.java
@@ -106,7 +106,7 @@ public class FSSuspensionCallbackImpl implements SuspensionHook {
     public synchronized byte[] retrieve(Integer id) throws IOException {
         long[] pos = index.get(id);
         if(pos == null)
-            throw new MissingNodeException(String.format("Neuron with id %d is missing in model label %d", id, modelLabel));
+            throw new MissingNodeException(String.format("Neuron with id %d is missing in model label %s", id, modelLabel));
 
         byte[] data = new byte[(int)pos[1]];
 


### PR DESCRIPTION
the formatting parameter is wrong in missingNodeException during retrieve wihich leads to a formatting exception
-dom