### PR TITLE
Refactor: Pulling Up Frequency and Probability

### DIFF
--- a/core/src/main/java/network/aika/elements/neurons/PatternNeuron.java
+++ b/core/src/main/java/network/aika/elements/neurons/PatternNeuron.java
@@ -22,7 +22,6 @@ import network.aika.elements.activations.Activation;
 import network.aika.elements.activations.PatternActivation;
 import network.aika.elements.synapses.*;
 import network.aika.sign.Sign;
-import network.aika.utils.Bound;
 import network.aika.utils.Utils;
 import network.aika.visitor.linking.LinkingOperator;
 import network.aika.visitor.linking.pattern.PatternDownVisitor;
@@ -31,15 +30,11 @@ import java.io.DataInput;
 import java.io.DataOutput;
 import java.io.IOException;
 
-import static network.aika.sign.Sign.POS;
-
 /**
  *
  * @author Lukas Molzberger
  */
 public class PatternNeuron extends ConjunctiveNeuron<PatternActivation> {
-
-    protected double frequency;
 
     protected SampleSpace sampleSpace = new SampleSpace();
 
@@ -112,12 +107,6 @@ public class PatternNeuron extends ConjunctiveNeuron<PatternActivation> {
         return frequency;
     }
 
-    public double getFrequency(Sign s, double n) {
-        return s == POS ?
-                frequency :
-                n - frequency;
-    }
-
     public void setFrequency(double f) {
         frequency = f;
         setModified();
@@ -127,17 +116,6 @@ public class PatternNeuron extends ConjunctiveNeuron<PatternActivation> {
         double n = sampleSpace.getN(range);
         double p = getProbability(s, n, addCurrentInstance);
         return Utils.surprisal(p);
-    }
-
-    public double getProbability(Sign s, double n, boolean addCurrentInstance) {
-        double f = getFrequency(s, n);
-
-        if(addCurrentInstance) {
-            f += 1.0;
-            n += 1.0;
-        }
-
-        return Bound.UPPER.probability(f, n);
     }
 
     @Override

--- a/core/src/main/java/network/aika/elements/synapses/PatternSynapse.java
+++ b/core/src/main/java/network/aika/elements/synapses/PatternSynapse.java
@@ -25,7 +25,6 @@ import network.aika.elements.neurons.Range;
 import network.aika.elements.neurons.SampleSpace;
 import network.aika.elements.neurons.BindingNeuron;
 import network.aika.sign.Sign;
-import network.aika.utils.Bound;
 import network.aika.utils.Utils;
 
 import java.io.DataInput;
@@ -50,10 +49,6 @@ public class PatternSynapse extends ConjunctiveSynapse<
         >
 {
 
-    protected double frequencyIPosOPos;
-    protected double frequencyIPosONeg;
-    protected double frequencyINegOPos;
-
     protected SampleSpace sampleSpace = new SampleSpace();
 
     public PatternSynapse() {
@@ -74,19 +69,6 @@ public class PatternSynapse extends ConjunctiveSynapse<
 
     public SampleSpace getSampleSpace() {
         return sampleSpace;
-    }
-
-    public double getFrequency(Sign inputSign, Sign outputSign, double n) {
-        if(inputSign == POS && outputSign == POS) {
-            return frequencyIPosOPos;
-        } else if(inputSign == POS && outputSign == NEG) {
-            return frequencyIPosONeg;
-        } else if(inputSign == NEG && outputSign == POS) {
-            return frequencyINegOPos;
-        }
-
-        //TODO:
-        return Math.max(n - (frequencyIPosOPos + frequencyIPosONeg + frequencyINegOPos), 0);
     }
 
     public void setFrequency(Sign inputSign, Sign outputSign, double f) {
@@ -158,18 +140,6 @@ public class PatternSynapse extends ConjunctiveSynapse<
         double n = sampleSpace.getN(range);
         double probability = getProbability(inputSign, outputSign, n, addCurrentInstance);
         return Utils.surprisal(probability);
-    }
-
-    public double getProbability(Sign inputSign, Sign outputSign, double n, boolean addCurrentInstance) {
-        double frequency = getFrequency(inputSign, outputSign, n);
-
-        // Add the current instance
-        if(addCurrentInstance) {
-            frequency += 1.0;
-            n += 1.0;
-        }
-
-        return Bound.UPPER.probability(frequency, n);
     }
 
     @Override


### PR DESCRIPTION
This refactoring method gets rid of duplicate code. If you need to make changes to a method, it’s better to do so in a single place than have to search for all duplicates of the method in subclasses. Now getFrequency and getProbability are in the same superclass.

As I don't have the test cases, I still suggest you to run test cases and ensure it's not breaking the code.